### PR TITLE
🐞 fix(install): Revert renaming Environment variables names for install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.ansible

--- a/.yamllint
+++ b/.yamllint
@@ -4,6 +4,8 @@ extends: default
 rules:
   braces:
     max-spaces-inside: 1
+  brackets:
+    max-spaces-inside: 1
   comments:
     min-spaces-from-content: 1
     require-starting-space: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,9 +56,9 @@
   shell: >
     {{ listmonk.home }}/bin/listmonk --config {{ listmonk.config_dir }}/config.toml --install {{ listmonk_bootstrap_install_args }} --yes 2>&1
   environment:
-    admin_user: "{{ listmonk_bootstrap_admin_user }}"
-    admin_password: "{{ listmonk_bootstrap_admin_password }}"
-    admin_api_user: "{{ listmonk_bootstrap_admin_api_user }}"
+    LISTMONK_ADMIN_USER: "{{ listmonk_bootstrap_admin_user }}"
+    LISTMONK_ADMIN_PASSWORD: "{{ listmonk_bootstrap_admin_password }}"
+    LISTMONK_ADMIN_API_USER: "{{ listmonk_bootstrap_admin_api_user }}"
   register: listmonk_bootstrap_output
   changed_when: true
   when: not listmonk_already_bootstrapped

--- a/tests/test-running-in-cicd.yml
+++ b/tests/test-running-in-cicd.yml
@@ -13,3 +13,138 @@
         listmonk_config_db_user: "postgres"
         listmonk_config_db_password: "S0meStr0ngP@ssword"
         debug_mode: false
+        listmonk_override_settings: true
+        listmonk_api_settings_payload:
+          app.site_name: Mailing list (managed by Ansible role)
+          app.root_url: http://localhost:9000
+          app.favicon_url: ""
+          app.from_email: "listmonk <noreply@listmonk.yoursite.com>"
+          app.logo_url: ""
+          app.concurrency: 10
+          app.message_rate: 10
+          app.batch_size: 1000
+          app.max_send_errors: 1000
+          app.message_sliding_window: false
+          app.message_sliding_window_duration: 1h
+          app.message_sliding_window_rate: 10000
+          app.cache_slow_queries: false
+          app.cache_slow_queries_interval: "0 3 * * *"
+          app.enable_public_archive: true
+          app.enable_public_subscription_page: true
+          app.enable_public_archive_rss_content: true
+          app.send_optin_confirmation: true
+          app.check_updates: true
+          app.notify_emails: [ ]
+          app.lang: en
+          privacy.individual_tracking: false
+          privacy.unsubscribe_header: true
+          privacy.allow_blocklist: true
+          privacy.allow_export: true
+          privacy.allow_wipe: true
+          privacy.allow_preferences: true
+          privacy.exportable:
+            - profile
+            - subscriptions
+            - campaign_views
+            - link_clicks
+          privacy.domain_blocklist: [ ]
+          privacy.domain_allowlist: [ ]
+          privacy.record_optin_ip: false
+          security.enable_captcha: false
+          security.captcha_key: ""
+          security.captcha_secret: ""
+          security.oidc:
+            enabled: false
+            client_id: ""
+            provider_url: ""
+            client_secret: ""
+            provider_name: ""
+          upload.provider: filesystem
+          upload.max_file_size: 5000
+          upload.extensions:
+            - jpg
+            - jpeg
+            - png
+            - gif
+            - svg
+            - "*"
+          upload.filesystem.upload_path: uploads
+          upload.filesystem.upload_uri: /uploads
+          upload.s3.url: https://ap-south-1.s3.amazonaws.com
+          upload.s3.public_url: ""
+          upload.s3.aws_access_key_id: ""
+          upload.s3.aws_secret_access_key: ""
+          upload.s3.aws_default_region: ap-south-1
+          upload.s3.bucket: ""
+          upload.s3.bucket_domain: ""
+          upload.s3.bucket_path: /
+          upload.s3.bucket_type: public
+          upload.s3.expiry: 167h
+          smtp:
+            - host: smtp.yoursite.com
+              port: 25
+              enabled: true
+              password: password
+              tls_type: STARTTLS
+              username: username
+              max_conns: 10
+              idle_timeout: 15s
+              wait_timeout: 5s
+              auth_protocol: cram
+              email_headers: [ ]
+              hello_hostname: ""
+              max_msg_retries: 2
+              tls_skip_verify: false
+            - host: smtp.gmail.com
+              port: 465
+              enabled: false
+              password: password
+              tls_type: TLS
+              username: username@gmail.com
+              max_conns: 10
+              idle_timeout: 15s
+              wait_timeout: 5s
+              auth_protocol: login
+              email_headers: [ ]
+              hello_hostname: ""
+              max_msg_retries: 2
+              tls_skip_verify: false
+          messengers: [ ]
+          bounce.enabled: false
+          bounce.webhooks_enabled: false
+          bounce.actions:
+            hard:
+              count: 1
+              action: blocklist
+            soft:
+              count: 2
+              action: none
+            complaint:
+              count: 1
+              action: blocklist
+          bounce.ses_enabled: false
+          bounce.sendgrid_enabled: false
+          bounce.sendgrid_key: ""
+          bounce.postmark:
+            enabled: false
+            password: ""
+            username: ""
+          bounce.forwardemail:
+            key: ""
+            enabled: false
+          bounce.mailboxes:
+            - host: pop.yoursite.com
+              port: 995
+              type: pop
+              enabled: false
+              password: password
+              username: username
+              return_path: bounce@listmonk.yoursite.com
+              tls_enabled: true
+              auth_protocol: userpass
+              scan_interval: 15m
+              tls_skip_verify: false
+          appearance.admin.custom_css: ""
+          appearance.admin.custom_js: ""
+          appearance.public.custom_css: ""
+          appearance.public.custom_js: ""


### PR DESCRIPTION
During renaming variables according to linter rules we accidently renamed environment variables This commit reverts environment names back to original names so install will start using them Also we update our test to use api_user token so it can fail if install can't create an api user token using one of environment variables